### PR TITLE
Use customer address to define billing and shipping address

### DIFF
--- a/models/customers.sql
+++ b/models/customers.sql
@@ -51,6 +51,7 @@ final as (
         customers.customer_id,
         customers.first_name,
         customers.last_name,
+        customers.address,
         customer_orders.first_order,
         customer_orders.most_recent_order,
         customer_orders.number_of_orders,

--- a/models/orders.sql
+++ b/models/orders.sql
@@ -12,6 +12,12 @@ with payments as (
 
 ),
 
+with customer as (
+
+    select * from {{ ref('stg_customers') }}
+
+),
+
 with order_payments as (
 
     select
@@ -36,6 +42,7 @@ with final as (
         orders.customer_id,
         orders.order_date,
         orders.status,
+        customers.address as shipping_address,
 
         {% for payment_method in payment_methods -%}
 
@@ -50,6 +57,9 @@ with final as (
 
     left join order_payments
         on orders.order_id = order_payments.order_id
+
+    left join customers
+        on orders.customer_id = customers.customer_id
 
 )
 

--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -13,7 +13,8 @@ renamed as (
     select
         id as customer_id,
         first_name,
-        last_name
+        last_name,
+        address
 
     from source
 


### PR DESCRIPTION
Add billing_address to stg_payments (taken from raw_customers)
Add shipping_address to stg_orders (taken from raw_customers)
Change shipping_address in orders to use shipping_address from stg_orders.

---
*This PR was automatically copied from foundational-demo/ex1-jaffle_shop#16*